### PR TITLE
Regional data - metadata files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: eurostat
 Type: Package
 Title: Tools for Eurostat Open Data
 Date: 2020-01-20
-Version: 3.5.2
+Version: 3.5.20001
 Encoding: UTF-8
 Authors@R: c(
   person("Leo", "Lahti", email = "leo.lahti@iki.fi", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5537-637X")),

--- a/R/get_eurostat_json.R
+++ b/R/get_eurostat_json.R
@@ -136,7 +136,7 @@ eurostat_json_url <- function(id, filters, lang){
   # prepare url
   url_list <- list(scheme = "http",
                    hostname = "ec.europa.eu",
-                   path = file.path("eurostat/wdds/rest/data/v1.1/json", 
+                   path = file.path("eurostat/wdds/rest/data/v2.1/json", 
                                     lang[1], id),
                    query = filters2)
   class(url_list) <- "url"

--- a/inst/extras/build.cran.sh
+++ b/inst/extras/build.cran.sh
@@ -1,5 +1,5 @@
 #/usr/bin/R CMD BATCH document.R
 ~/bin/R-3.6.2/bin/R CMD build ../../ --no-build-vignettes
-~/bin/R-3.6.2/bin/R CMD check --as-cran eurostat_3.5.1.tar.gz  --no-build-vignettes
-~/bin/R-3.6.2/bin/R CMD INSTALL eurostat_3.5.1.tar.gz
+~/bin/R-3.6.2/bin/R CMD check --as-cran eurostat_3.5.20001.tar.gz  --no-build-vignettes
+~/bin/R-3.6.2/bin/R CMD INSTALL eurostat_3.5.20001.tar.gz
 


### PR DESCRIPTION
My apologies for not being clerar in the earlier PR and I was not sure of your review process.

So, the missing data files are created by the data-raw/nuts_coding.R file, usthing the usethis:: infrastructure like the country lists in the same folder.  So, if you want to be fully reproducible, you can create the new versions of the tidy correspondence tables. 

I now committed two copies, just made right now, to the data/ folder.   When building the pakcage, devtools will not automatically run the contents of the data-raw folder. But if you want to make sure it works, you can test it on your system. The only problem there may be is the the way different systems handle tempfile () pathes.  I could only test it on a Windows laptop, but it should work fine on Linux, too.